### PR TITLE
Fixing empty screen issue while coming back from CreateNewPaletteScreen.

### DIFF
--- a/app/src/main/java/com/akashk/palette/palettelist/PaletteListScreen.kt
+++ b/app/src/main/java/com/akashk/palette/palettelist/PaletteListScreen.kt
@@ -2,7 +2,6 @@ package com.akashk.palette.palettelist
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.akashk.palette.destinations.CreateNewPaletteScreenDestination
@@ -17,17 +16,11 @@ fun PaletteListScreen(
     viewModel: PaletteListViewModel = hiltViewModel(),
 ) {
     val viewState = viewModel.viewState.collectAsState()
-    DisposableEffect(key1 = viewState.value) {
-        if (viewState.value is PaletteListViewState.AddNewPalette) {
-            // Navigate to CreateNewPaletteScreen.
-            navigator.navigate(CreateNewPaletteScreenDestination)
-        }
-        onDispose { }
-    }
+
     PaletteScreenContent(
         viewState = viewState.value,
         onAddClick = {
-            viewModel.addNewPalette()
+            navigator.navigate(CreateNewPaletteScreenDestination)
         },
     )
 }

--- a/app/src/main/java/com/akashk/palette/palettelist/PaletteListViewModel.kt
+++ b/app/src/main/java/com/akashk/palette/palettelist/PaletteListViewModel.kt
@@ -30,10 +30,6 @@ class PaletteListViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
-    fun addNewPalette() {
-        _viewState.value = PaletteListViewState.AddNewPalette
-    }
-
     private fun getPaletteListViewState(result: Result<List<Palette>>): PaletteListViewState {
         return when (result) {
             is Result.Error -> {

--- a/app/src/main/java/com/akashk/palette/palettelist/PaletteListViewState.kt
+++ b/app/src/main/java/com/akashk/palette/palettelist/PaletteListViewState.kt
@@ -22,10 +22,4 @@ sealed class PaletteListViewState {
     data class Error(
         val errorMessage: UIText,
     ) : PaletteListViewState()
-
-    /**
-     * This indicates the add new palette button is clicked
-     * and user will be navigate to Add palette Screen.
-     */
-    object AddNewPalette : PaletteListViewState()
 }

--- a/app/src/test/java/com/akashk/palette/palettelistscreen/PaletteListViewModelRobot.kt
+++ b/app/src/test/java/com/akashk/palette/palettelistscreen/PaletteListViewModelRobot.kt
@@ -21,10 +21,6 @@ class PaletteListViewModelRobot {
         fakePaletteRepository.mockPaletteListResult(result)
     }
 
-    fun mockAddNewPaletteState() = apply {
-        viewModel.addNewPalette()
-    }
-
     fun assertViewState(expectedViewState: PaletteListViewState) = apply {
         val actualViewState = viewModel.viewState.value
         assertThat(actualViewState).isEqualTo(expectedViewState)

--- a/app/src/test/java/com/akashk/palette/palettelistscreen/PaletteListViewModelTest.kt
+++ b/app/src/test/java/com/akashk/palette/palettelistscreen/PaletteListViewModelTest.kt
@@ -5,7 +5,6 @@ import com.akashk.palette.core.Result
 import com.akashk.palette.core.ui.UIText
 import com.akashk.palette.domain.data.Palette
 import com.akashk.palette.palettelist.PaletteListViewState
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -44,30 +43,6 @@ class PaletteListViewModelTest {
             .buildViewModel()
             .assertViewState(
                 expectedViewState = PaletteListViewState.Error(UIText.StringText(errorMessage))
-            )
-    }
-
-    @Test
-    fun navigateToAddNewPaletteScreen() = runBlockingTest {
-
-        val palette = Palette(
-            id = 1,
-            name = "Palette 1",
-            colorList = listOf("#6750a4", "#4534ff", "#0004fc", "#6750d8")
-        )
-
-        val expectedList = listOf(palette)
-        val paletteListResult = Result.Success(expectedList)
-
-        testRobot
-            .mockAllPalettesResult(paletteListResult)
-            .buildViewModel()
-            .assertViewState(
-                expectedViewState = PaletteListViewState.Loaded(expectedList)
-            )
-            .mockAddNewPaletteState()
-            .assertViewState(
-                expectedViewState = PaletteListViewState.AddNewPalette
             )
     }
 }


### PR DESCRIPTION
## Summary

* Previously while navigating back from CreateNewPaletteScreen PaletteListScreen did not show any composable.

## How It Was Tested

* Instead of using Stateflow event directly added navigator code in onAddClick callback.
